### PR TITLE
fix for cloudinit under uefi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Feel free to change the 8001 to whatever you like, so long as you replace the 80
     sudo qm importdisk 8001 noble-server-cloudimg-amd64.img local-zfs
     sudo qm set 8001 --scsihw virtio-scsi-pci --virtio0 local-zfs:vm-8001-disk-1,discard=on
     sudo qm set 8001 --boot order=virtio0
-    sudo qm set 8001 --ide2 local-zfs:cloudinit
+    sudo qm set 8001 --scsi1 local-zfs:cloudinit
 
 The first command imports that image we downloaded earlier, if your disk storage is not local-zfs (for example local-lvm) then replace it with whatever you wish. Next command attaches the disk to the VM. If your disk storage is not on SSDs (which it should be) omit `,discard=on`. The third command sets the boot order. Fourth adds the cloudinit pseudo-cdrom drive.
 

--- a/samples/debian/debian-12-cloudinit+docker.sh
+++ b/samples/debian/debian-12-cloudinit+docker.sh
@@ -18,7 +18,7 @@ sudo qm create $VMID --name "debian-12-template-dcoker" --ostype l26 \
 sudo qm importdisk $VMID debian-12-generic-amd64+docker.qcow2 $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
-sudo qm set $VMID --ide2 $STORAGE:cloudinit
+sudo qm set $VMID --scsi1 $STORAGE:cloudinit
 
 cat << EOF | sudo tee /mnt/pve/remote-nfs/snippets/debian-12-docker.yaml
 #cloud-config

--- a/samples/debian/debian-12-cloudinit.sh
+++ b/samples/debian/debian-12-cloudinit.sh
@@ -18,7 +18,7 @@ sudo qm create $VMID --name "debian-12-template" --ostype l26 \
 sudo qm importdisk $VMID debian-12-generic-amd64.qcow2 $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
-sudo qm set $VMID --ide2 $STORAGE:cloudinit
+sudo qm set $VMID --scsi1 $STORAGE:cloudinit
 
 cat << EOF | sudo tee /var/lib/vz/snippets/debian-12.yaml
 #cloud-config

--- a/samples/ubuntu/ubuntu-noble-cloudinit+nvidia+runtime.sh
+++ b/samples/ubuntu/ubuntu-noble-cloudinit+nvidia+runtime.sh
@@ -18,7 +18,7 @@ sudo qm create $VMID --name "ubuntu-noble-template-nvidia-runtime" --ostype l26 
 sudo qm importdisk $VMID noble-server-cloudimg-amd64.img $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
-sudo qm set $VMID --ide2 $STORAGE:cloudinit
+sudo qm set $VMID --scsi1 $STORAGE:cloudinit
 
 cat << EOF | sudo tee /var/lib/vz/snippets/ubuntu-noble-runtime.yaml
 #cloud-config

--- a/samples/ubuntu/ubuntu-noble-cloudinit.sh
+++ b/samples/ubuntu/ubuntu-noble-cloudinit.sh
@@ -18,7 +18,7 @@ sudo qm create $VMID --name "ubuntu-noble-template" --ostype l26 \
 sudo qm importdisk $VMID noble-server-cloudimg-amd64.img $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
-sudo qm set $VMID --ide2 $STORAGE:cloudinit
+sudo qm set $VMID --scsi1 $STORAGE:cloudinit
 
 cat << EOF | sudo tee /var/lib/vz/snippets/ubuntu.yaml
 #cloud-config


### PR DESCRIPTION
I wasn't able to ssh or login to the console using the "ide" driver for the cloud init image under uefi.

Changing the driver to scsi runs as expected. I tested using Ubuntu "Noble" minimal server. This seems to be a [known issue](https://forum.proxmox.com/threads/cloud-init-image-only-applies-configuration-on-second-boot.93414/) with proxmox, did you not face the same problem?

Side-note: I also recommend the qxl (spice) display driver which is as simple as `--vga qxl`

Here's a slightly modified script to the one I used to generate the (working) image, for reference:

```bash
#!/bin/bash

vm_id="$1"
vm_name="$2"
source_image="$3"
storage_disk="$4"
net_bridge="$5"
ciuser="theuser"
    
[ -z "$vm_id" ] && echo "vmid is required" && exit 1 
[ -z "$vm_name" ] && echo "vm name is required" && exit 2 
[ -z "$source_image" ] && echo "source image is required" && exit 3 
[ -z "$net_bridge" ] && net_bridge="lan1" 
[ -z "$storage_disk" ] && storage_disk="local-zfs" 
    
echo -n "Enter initial vm password: " 
read -s -r password 
echo 
    
qm create "$vm_id" \ 
        --name "$vm_name" \ 
        --memory 512 \ 
        --agent 1 \ 
        --ostype l26 \ 
        --net0 virtio,bridge="$net_bridge" \ 
        --bios ovmf \ 
        --machine q35 \ 
        --efidisk0 "$storage_disk:0,pre-enrolled-keys=0" \ 
        --cpu host --socket 1 --cores 1 \ 
        --vga qxl --serial0 socket 
qm importdisk "$vm_id" "$source_image" "$storage_disk" 
qm set "$vm_id" --scsihw virtio-scsi-pci --virtio0 "${storage_disk}:vm-${vm_id}-disk-1,discard=on" 
qm set "$vm_id" --boot order=virtio0 
qm set "$vm_id" --scsi1 "${storage_disk}:cloudinit" 
sudo qm set "$vm_id" --tags ubuntu-template,24.04,cloudinit 
sudo qm set "$vm_id" --ciuser "$ciuser"
sudo qm set "$vm_id" --cipassword "$(openssl passwd -6 "$password")" 
sudo qm set "$vm_id" --sshkeys ~/.ssh/authorized_keys 
sudo qm set "$vm_id" --ipconfig0 ip=dhcp
```