### PR TITLE
Add checksum verification and safer image handling to cloud-init sample scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ For this guide I have made a few assumptions:
 * You want to use Ubuntu 24.04
 * You have SSH keys stored in ~/.ssh/authorized_keys of your regular user's home folder
 
+## Quick start
+If you want to quickly create an ubuntu VM template using this guide, you can run the following:
+```
+export VMID=8300 STORAGE=local-lvm
+curl -fsSL https://raw.githubusercontent.com/UntouchedWagons/Ubuntu-CloudInit-Docs/main/samples/ubuntu/ubuntu-noble-cloudinit.sh | bash
+```
+
 ## The basics
 
 The first step is to enable support for snippets in the local dataset. Log into the Proxmox web UI and click Datacenter on the left, then Storage. Click local then Edit and a small window will pop up. In the Content drop down click on snippets, then OK.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For this guide I have made a few assumptions:
 ## Quick start
 If you want to quickly create an ubuntu VM template using this guide, you can run the following:
 ```
-export VMID=8300 STORAGE=local-lvm
+export VMID=8300 STORAGE=local-zfs
 curl -fsSL https://raw.githubusercontent.com/UntouchedWagons/Ubuntu-CloudInit-Docs/main/samples/ubuntu/ubuntu-noble-cloudinit.sh | bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ export VMID=8300 STORAGE=local-zfs
 curl -fsSL https://raw.githubusercontent.com/UntouchedWagons/Ubuntu-CloudInit-Docs/main/samples/ubuntu/ubuntu-noble-cloudinit.sh | bash
 ```
 
+Other scripts are available in the [samples](./samples) directory, and can be used similarly to the above.
+
 ## The basics
 
 The first step is to enable support for snippets in the local dataset. Log into the Proxmox web UI and click Datacenter on the left, then Storage. Click local then Edit and a small window will pop up. In the Content drop down click on snippets, then OK.

--- a/samples/debian/debian-12-cloudinit+docker.sh
+++ b/samples/debian/debian-12-cloudinit+docker.sh
@@ -1,13 +1,38 @@
 #! /bin/bash
 
-VMID=8001
-STORAGE=local-zfs
+set -xe
 
-set -x
-rm -f debian-12-generic-amd64+docker.qcow2
-wget -q https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2 -O debian-12-generic-amd64+docker.qcow2
-qemu-img resize debian-12-generic-amd64+docker.qcow2 8G
-sudo qm destroy $VMID
+VMID="${VMID:-8001}"
+STORAGE="${STORAGE:-local-zfs}"
+
+IMG="debian-12-generic-amd64.qcow2"
+BASE_URL="https://cloud.debian.org/images/cloud/bookworm/latest"
+EXPECTED_SHA=$(wget -qO- "$BASE_URL/SHA512SUMS" | awk '/'$IMG'/{print $1}')
+
+download() {
+    wget -q "$BASE_URL/$IMG"
+}
+
+verify() {
+    sha512sum "$IMG" | awk '{print $1}'
+}
+
+[ ! -f "$IMG" ] && download
+
+ACTUAL_SHA=$(verify)
+
+if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+    rm -f "$IMG"
+    download
+    ACTUAL_SHA=$(verify)
+    [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ] && exit 1
+fi
+
+rm -f debian-12-generic-amd64-resized.qcow2
+cp debian-12-generic-amd64.qcow2 debian-12-generic-amd64-resized.qcow2
+qemu-img resize debian-12-generic-amd64-resized.qcow2 8G
+
+sudo qm destroy $VMID || true
 sudo qm create $VMID --name "debian-12-template-docker" --ostype l26 \
     --memory 1024 --balloon 0 \
     --agent 1 \
@@ -15,7 +40,7 @@ sudo qm create $VMID --name "debian-12-template-docker" --ostype l26 \
     --cpu x86-64-v2-AES --cores 1 --numa 1 \
     --vga serial0 --serial0 socket  \
     --net0 virtio,bridge=vmbr0,mtu=1
-sudo qm importdisk $VMID debian-12-generic-amd64+docker.qcow2 $STORAGE
+sudo qm importdisk $VMID debian-12-generic-amd64-resized.qcow2 $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
 sudo qm set $VMID --scsi1 $STORAGE:cloudinit

--- a/samples/debian/debian-13-cloudinit.sh
+++ b/samples/debian/debian-13-cloudinit.sh
@@ -1,13 +1,38 @@
 #! /bin/bash
 
-VMID=8000
-STORAGE=local-zfs
+set -xe
 
-set -x
-rm -f debian-13-generic-amd64.qcow2
-wget -q https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2
-qemu-img resize debian-13-generic-amd64.qcow2 8G
-sudo qm destroy $VMID
+VMID="${VMID:-8000}"
+STORAGE="${STORAGE:-local-zfs}"
+
+IMG="debian-13-generic-amd64.qcow2"
+BASE_URL="https://cloud.debian.org/images/cloud/trixie/latest"
+EXPECTED_SHA=$(wget -qO- "$BASE_URL/SHA512SUMS" | awk '/'$IMG'/{print $1}')
+
+download() {
+    wget -q "$BASE_URL/$IMG"
+}
+
+verify() {
+    sha512sum "$IMG" | awk '{print $1}'
+}
+
+[ ! -f "$IMG" ] && download
+
+ACTUAL_SHA=$(verify)
+
+if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+    rm -f "$IMG"
+    download
+    ACTUAL_SHA=$(verify)
+    [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ] && exit 1
+fi
+
+rm -f debian-13-generic-amd64-resized.qcow2
+cp debian-13-generic-amd64.qcow2 debian-13-generic-amd64-resized.qcow2
+qemu-img resize debian-13-generic-amd64-resized.qcow2 8G
+
+sudo qm destroy $VMID || true
 sudo qm create $VMID --name "debian-13-template" --ostype l26 \
     --memory 1024 --balloon 0 \
     --agent 1 \
@@ -15,7 +40,7 @@ sudo qm create $VMID --name "debian-13-template" --ostype l26 \
     --cpu x86-64-v2-AES --cores 1 --numa 1 \
     --vga serial0 --serial0 socket  \
     --net0 virtio,bridge=vmbr0,mtu=1
-sudo qm importdisk $VMID debian-13-generic-amd64.qcow2 $STORAGE
+sudo qm importdisk $VMID debian-13-generic-amd64-resized.qcow2 $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
 sudo qm set $VMID --scsi1 $STORAGE:cloudinit

--- a/samples/ubuntu/ubuntu-noble-cloudinit+nvidia+runtime.sh
+++ b/samples/ubuntu/ubuntu-noble-cloudinit+nvidia+runtime.sh
@@ -1,13 +1,38 @@
 #! /bin/bash
 
-VMID=8202
-STORAGE=local-zfs
+set -xe
 
-set -x
-rm -f noble-server-cloudimg-amd64+nivida.img
-wget -q https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img -O noble-server-cloudimg-amd64+nivida.img
-qemu-img resize noble-server-cloudimg-amd64.img 8G
-sudo qm destroy $VMID
+VMID="${VMID:-8202}"
+STORAGE="${STORAGE:-local-zfs}"
+
+IMG="noble-server-cloudimg-amd64.img"
+BASE_URL="https://cloud-images.ubuntu.com/noble/current"
+EXPECTED_SHA=$(wget -qO- "$BASE_URL/SHA256SUMS" | awk '/'$IMG'/{print $1}')
+
+download() {
+    wget -q "$BASE_URL/$IMG"
+}
+
+verify() {
+    sha256sum "$IMG" | awk '{print $1}'
+}
+
+[ ! -f "$IMG" ] && download
+
+ACTUAL_SHA=$(verify)
+
+if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+    rm -f "$IMG"
+    download
+    ACTUAL_SHA=$(verify)
+    [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ] && exit 1
+fi
+
+rm -f noble-server-cloudimg-amd64-resized.img
+cp noble-server-cloudimg-amd64.img noble-server-cloudimg-amd64-resized.img
+qemu-img resize noble-server-cloudimg-amd64-resized.img 8G
+
+sudo qm destroy $VMID || true
 sudo qm create $VMID --name "ubuntu-noble-template-nvidia-runtime" --ostype l26 \
     --memory 1024 --balloon 0 \
     --agent 1 \
@@ -15,7 +40,7 @@ sudo qm create $VMID --name "ubuntu-noble-template-nvidia-runtime" --ostype l26 
     --cpu host --socket 1 --cores 1 \
     --vga serial0 --serial0 socket  \
     --net0 virtio,bridge=vmbr0
-sudo qm importdisk $VMID noble-server-cloudimg-amd64.img $STORAGE
+sudo qm importdisk $VMID noble-server-cloudimg-amd64-resized.img $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
 sudo qm set $VMID --scsi1 $STORAGE:cloudinit

--- a/samples/ubuntu/ubuntu-noble-cloudinit.sh
+++ b/samples/ubuntu/ubuntu-noble-cloudinit.sh
@@ -1,13 +1,38 @@
 #! /bin/bash
 
-VMID=8200
-STORAGE=local-zfs
+set -xe
 
-set -x
-rm -f noble-server-cloudimg-amd64.img
-wget -q https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
-qemu-img resize noble-server-cloudimg-amd64.img 8G
-sudo qm destroy $VMID
+VMID="${VMID:-8200}"
+STORAGE="${STORAGE:-local-zfs}"
+
+IMG="noble-server-cloudimg-amd64.img"
+BASE_URL="https://cloud-images.ubuntu.com/noble/current"
+EXPECTED_SHA=$(wget -qO- "$BASE_URL/SHA256SUMS" | awk '/'$IMG'/{print $1}')
+
+download() {
+    wget -q "$BASE_URL/$IMG"
+}
+
+verify() {
+    sha256sum "$IMG" | awk '{print $1}'
+}
+
+[ ! -f "$IMG" ] && download
+
+ACTUAL_SHA=$(verify)
+
+if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+    rm -f "$IMG"
+    download
+    ACTUAL_SHA=$(verify)
+    [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ] && exit 1
+fi
+
+rm -f noble-server-cloudimg-amd64-resized.img
+cp noble-server-cloudimg-amd64.img noble-server-cloudimg-amd64-resized.img
+qemu-img resize noble-server-cloudimg-amd64-resized.img 8G
+
+sudo qm destroy $VMID || true
 sudo qm create $VMID --name "ubuntu-noble-template" --ostype l26 \
     --memory 1024 --balloon 0 \
     --agent 1 \
@@ -15,7 +40,7 @@ sudo qm create $VMID --name "ubuntu-noble-template" --ostype l26 \
     --cpu host --socket 1 --cores 1 \
     --vga serial0 --serial0 socket  \
     --net0 virtio,bridge=vmbr0
-sudo qm importdisk $VMID noble-server-cloudimg-amd64.img $STORAGE
+sudo qm importdisk $VMID noble-server-cloudimg-amd64-resized.img $STORAGE
 sudo qm set $VMID --scsihw virtio-scsi-pci --virtio0 $STORAGE:vm-$VMID-disk-1,discard=on
 sudo qm set $VMID --boot order=virtio0
 sudo qm set $VMID --scsi1 $STORAGE:cloudinit


### PR DESCRIPTION
- Add reliable image verification
- Resize image not-in-place, so users don't need to redownload the image on every script run
- Allow ENV passing for VMID and STORAGE
- Add a Quick Start section in the README to include a one-copy command